### PR TITLE
Add xl!unsetprefix command, better support for wine, and Retainer Sale support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Download Dalamud
         run: |
-          Invoke-WebRequest -Uri https://goaaats.github.io/ffxiv/tools/launcher/addons/Hooks/latest.zip -OutFile latest.zip
+          Invoke-WebRequest -Uri https://github.com/goatcorp/dalamud-distrib/raw/main/latest.zip -OutFile latest.zip
           Expand-Archive -Force latest.zip "$env:AppData\XIVLauncher\addon\Hooks\dev"
         
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         run: msbuild Dalamud.DiscordBridge.sln /p:Configuration=Release
 
       - name: Archive
-        run: Compress-Archive -Path Dalamud.DiscordBridge\bin\Release\* -DestinationPath Dalamud.DiscordBridge.zip
+        run: Compress-Archive -Path Dalamud.DiscordBridge\bin\Release\net472\* -DestinationPath Dalamud.DiscordBridge.zip
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ name: Build Dalamud.DiscordBridge
 # Controls when the action will run. Triggers the workflow on push
 on:
   push:
-    branches: 'testing'
+    branches: 'master'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Download Dalamud
         run: |
           Invoke-WebRequest -Uri https://goaaats.github.io/ffxiv/tools/launcher/addons/Hooks/latest.zip -OutFile latest.zip
-          Expand-Archive -Force latest.zip "$env:AppData\XIVLauncher\addon\Hooks\"
+          Expand-Archive -Force latest.zip "$env:AppData\XIVLauncher\addon\Hooks\dev"
         
       - name: Build
         run: msbuild Dalamud.DiscordBridge.sln /p:Configuration=Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+        with:
+          submodules: "recursive"  
       
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1.0.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Build Dalamud.DiscordBridge
+
+# Controls when the action will run. Triggers the workflow on push
+on:
+  push:
+    branches: 'testing'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: [windows-latest]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.0.2
+        
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1.0.5
+        
+      - name: Restore NuGet Packages
+        run: nuget restore Dalamud.DiscordBridge.sln
+
+      - name: Download Dalamud
+        run: |
+          Invoke-WebRequest -Uri https://goaaats.github.io/ffxiv/tools/launcher/addons/Hooks/latest.zip -OutFile latest.zip
+          Expand-Archive -Force latest.zip "$env:AppData\XIVLauncher\addon\Hooks\"
+        
+      - name: Build
+        run: msbuild Dalamud.DiscordBridge.sln /p:Configuration=Release
+
+      - name: Archive
+        run: Compress-Archive -Path Dalamud.DiscordBridge\bin\Release\* -DestinationPath Dalamud.DiscordBridge.zip
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.run_number }}
+          release_name: Dalamud.DiscordBridge - Build ${{ github.run_number }}
+          draft: false
+          prerelease: true
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./Dalamud.DiscordBridge.zip
+          asset_name: Dalamud.DiscordBridge-Build-${{ github.run_number }}.zip
+          asset_content_type: application/zip 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Download Dalamud
         run: |
-          Invoke-WebRequest -Uri https://goaaats.github.io/ffxiv/tools/launcher/addons/Hooks/latest.zip -OutFile latest.zip
+          Invoke-WebRequest -Uri https://github.com/goatcorp/dalamud-distrib/raw/main/latest.zip -OutFile latest.zip
           Expand-Archive -Force latest.zip "$env:AppData\XIVLauncher\addon\Hooks\dev\"
         
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Download Dalamud
         run: |
           Invoke-WebRequest -Uri https://goaaats.github.io/ffxiv/tools/launcher/addons/Hooks/latest.zip -OutFile latest.zip
-          Expand-Archive -Force latest.zip "$env:AppData\XIVLauncher\addon\Hooks\"
+          Expand-Archive -Force latest.zip "$env:AppData\XIVLauncher\addon\Hooks\dev\"
         
       - name: Build
         run: msbuild Dalamud.DiscordBridge.sln /p:Configuration=Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Create Dalamud.DiscordBridge Release
+
+# Controls when the action will run. Triggers the workflow on tag creation
+on:
+  push:
+    tags:
+      - '*'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: [windows-latest]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.0.2
+        
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1.0.5
+        
+      - name: Restore NuGet Packages
+        run: nuget restore Dalamud.DiscordBridge.sln
+
+      - name: Download Dalamud
+        run: |
+          Invoke-WebRequest -Uri https://goaaats.github.io/ffxiv/tools/launcher/addons/Hooks/latest.zip -OutFile latest.zip
+          Expand-Archive -Force latest.zip "$env:AppData\XIVLauncher\addon\Hooks\"
+        
+      - name: Build
+        run: msbuild Dalamud.DiscordBridge.sln /p:Configuration=Release
+
+        
+      - name: Archive
+        run: Compress-Archive -Path Dalamud.DiscordBridge\bin\Release\* -DestinationPath Dalamud.DiscordBridge.zip
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Dalamud.DiscordBridge - ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./Dalamud.DiscordBridge.zip
+          asset_name: Dalamud.DiscordBridge-Release-${{ github.ref }}.zip
+          asset_content_type: application/zip 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
         
       - name: Archive
-        run: Compress-Archive -Path Dalamud.DiscordBridge\bin\Release\* -DestinationPath Dalamud.DiscordBridge.zip
+        run: Compress-Archive -Path Dalamud.DiscordBridge\bin\Release\net472\* -DestinationPath Dalamud.DiscordBridge.zip
 
       - name: Create Release
         id: create_release

--- a/Dalamud.DiscordBridge/Configuration.cs
+++ b/Dalamud.DiscordBridge/Configuration.cs
@@ -11,6 +11,8 @@ namespace Dalamud.DiscordBridge
     {
         public int Version { get; set; }
 
+        public long DuplicateCheckMS { get; set; } = 0;
+
         [JsonIgnore] private DalamudPluginInterface pluginInterface;
 
         public string DiscordToken { get; set; } = string.Empty;

--- a/Dalamud.DiscordBridge/Configuration.cs
+++ b/Dalamud.DiscordBridge/Configuration.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using Dalamud.Configuration;
 using Dalamud.DiscordBridge.Model;
-using Dalamud.Game.Chat;
+using Dalamud.Game.Text;
 using Dalamud.Plugin;
 using Newtonsoft.Json;
 

--- a/Dalamud.DiscordBridge/Constant.cs
+++ b/Dalamud.DiscordBridge/Constant.cs
@@ -8,8 +8,8 @@ namespace Dalamud.DiscordBridge
 {
     static class Constant
     {
-        public const string HelpLink = "https://github.com/goaaats/Dalamud.DiscordBridge/wiki/Setup-Guide";
-        public const string KindListLink = "https://github.com/goaaats/Dalamud.DiscordBridge/wiki/Chat-kinds";
+        public const string HelpLink = "https://github.com/reiichi001/Dalamud.DiscordBridge/wiki/Setup-Guide";
+        public const string KindListLink = "https://github.com/reiichi001/Dalamud.DiscordBridge/wiki/Chat-kinds";
         public const string DiscordJoinLink = "https://discord.gg/3NMcUV5";
         public const string LogoLink = "https://raw.githubusercontent.com/goatcorp/DalamudAssets/master/UIRes/logo.png";
     }

--- a/Dalamud.DiscordBridge/Dalamud.DiscordBridge.csproj
+++ b/Dalamud.DiscordBridge/Dalamud.DiscordBridge.csproj
@@ -26,35 +26,35 @@
 
   <ItemGroup>
     <Reference Include="Dalamud">
-      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks\dev')" >$(AppData)\XIVLauncher\addon\Hooks\dev\Dalamud.dll</HintPath>
+      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks\dev')">$(AppData)\XIVLauncher\addon\Hooks\dev\Dalamud.dll</HintPath>
       <HintPath Condition="Exists('$(DalamudHooks)')">$(DalamudHooks)\Dalamud.dll</HintPath>
       <HintPath Condition="Exists('..\Dalamud\Dalamud\bin\Debug')">..\Dalamud\Dalamud\bin\Debug\Dalamud.dll</HintPath>
       <HintPath Condition="Exists('..\..\Dalamud\Dalamud\bin\Debug')">..\..\Dalamud\Dalamud\bin\Debug\Dalamud.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="ImGui.NET">
-      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks\dev')" >$(AppData)\XIVLauncher\addon\Hooks\dev\ImGui.NET.dll</HintPath>
+      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks\dev')">$(AppData)\XIVLauncher\addon\Hooks\dev\ImGui.NET.dll</HintPath>
       <HintPath Condition="Exists('$(DalamudHooks)')">$(DalamudHooks)\ImGuiScene.dll</HintPath>
       <HintPath Condition="Exists('..\Dalamud\Dalamud\bin\Debug')">..\Dalamud\Dalamud\bin\Debug\ImGui.NET.dll</HintPath>
       <HintPath Condition="Exists('..\..\Dalamud\Dalamud\bin\Debug')">..\..\Dalamud\Dalamud\bin\Debug\ImGui.NET.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="ImGuiScene">
-      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks\dev')" >$(AppData)\XIVLauncher\addon\Hooks\dev\ImGuiScene.dll</HintPath>
+      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks\dev')">$(AppData)\XIVLauncher\addon\Hooks\dev\ImGuiScene.dll</HintPath>
       <HintPath Condition="Exists('$(DalamudHooks)')">$(DalamudHooks)\ImGuiScene.dll</HintPath>
       <HintPath Condition="Exists('..\Dalamud\Dalamud\bin\Debug')">..\Dalamud\Dalamud\bin\Debug\ImGuiScene.dll</HintPath>
       <HintPath Condition="Exists('..\..\Dalamud\Dalamud\bin\Debug')">..\..\Dalamud\Dalamud\bin\Debug\ImGuiScene.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Lumina">
-      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks\dev')" >$(AppData)\XIVLauncher\addon\Hooks\dev\Lumina.dll</HintPath>
+      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks\dev')">$(AppData)\XIVLauncher\addon\Hooks\dev\Lumina.dll</HintPath>
       <HintPath Condition="Exists('$(DalamudHooks)')">$(DalamudHooks)\Lumina.dll</HintPath>
       <HintPath Condition="Exists('..\Dalamud\Dalamud\bin\Debug')">..\Dalamud\Dalamud\bin\Debug\Lumina.dll</HintPath>
       <HintPath Condition="Exists('..\..\Dalamud\Dalamud\bin\Debug')">..\..\Dalamud\Dalamud\bin\Debug\Lumina.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Lumina.Excel">
-      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks\dev')" >$(AppData)\XIVLauncher\addon\Hooks\dev\Lumina.Excel.dll</HintPath>
+      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks\dev')">$(AppData)\XIVLauncher\addon\Hooks\dev\Lumina.Excel.dll</HintPath>
       <HintPath Condition="Exists('$(DalamudHooks)')">$(DalamudHooks)\Lumina.Excel.dll</HintPath>
       <HintPath Condition="Exists('..\Dalamud\Dalamud\bin\Debug')">..\Dalamud\Dalamud\bin\Debug\Lumina.Excel.dll</HintPath>
       <HintPath Condition="Exists('..\..\Dalamud\Dalamud\bin\Debug')">..\..\Dalamud\Dalamud\bin\Debug\Lumina.Excel.dll</HintPath>
@@ -62,7 +62,7 @@
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json">
-      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks\dev')" >$(AppData)\XIVLauncher\addon\Hooks\dev\Newtonsoft.Json.dll</HintPath>
+      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks\dev')">$(AppData)\XIVLauncher\addon\Hooks\dev\Newtonsoft.Json.dll</HintPath>
       <HintPath Condition="Exists('$(DalamudHooks)')">$(DalamudHooks)\Newtonsoft.Json.dll</HintPath>
       <HintPath Condition="Exists('..\Dalamud\Dalamud\bin\Debug')">..\Dalamud\Dalamud\bin\Debug\Newtonsoft.Json.dll</HintPath>
       <HintPath Condition="Exists('..\..\Dalamud\Dalamud\bin\Debug')">..\..\Dalamud\Dalamud\bin\Debug\Newtonsoft.Json.dll</HintPath>

--- a/Dalamud.DiscordBridge/Dalamud.DiscordBridge.csproj
+++ b/Dalamud.DiscordBridge/Dalamud.DiscordBridge.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Discord.Net.Providers.WS4Net" Version="2.2.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/Dalamud.DiscordBridge/Dalamud.DiscordBridge.csproj
+++ b/Dalamud.DiscordBridge/Dalamud.DiscordBridge.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <AssemblyVersion>1.0.1.1</AssemblyVersion>
-    <FileVersion>1.0.1.1</FileVersion>
-    <Version>1.0.1.1</Version>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
+    <Version>1.1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,7 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net.Providers.WS4Net" Version="2.2.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/Dalamud.DiscordBridge/Dalamud.DiscordBridge.csproj
+++ b/Dalamud.DiscordBridge/Dalamud.DiscordBridge.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <FileVersion>1.1.0.0</FileVersion>
-    <Version>1.1.0.0</Version>
+    <AssemblyVersion>1.1.0.1</AssemblyVersion>
+    <FileVersion>1.1.0.1</FileVersion>
+    <Version>1.1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="DalamudPackager" Version="1.2.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/Dalamud.DiscordBridge/Dalamud.DiscordBridge.csproj
+++ b/Dalamud.DiscordBridge/Dalamud.DiscordBridge.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <AssemblyVersion>1.0.0.2</AssemblyVersion>
-    <FileVersion>1.0.0.2</FileVersion>
-    <Version>1.0.0.2</Version>
+    <AssemblyVersion>1.0.1.0</AssemblyVersion>
+    <FileVersion>1.0.1.0</FileVersion>
+    <Version>1.0.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,35 +26,35 @@
 
   <ItemGroup>
     <Reference Include="Dalamud">
-      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks')">$(AppData)\XIVLauncher\addon\Hooks\Dalamud.dll</HintPath>
+      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks\dev')" >$(AppData)\XIVLauncher\addon\Hooks\dev\Dalamud.dll</HintPath>
       <HintPath Condition="Exists('$(DalamudHooks)')">$(DalamudHooks)\Dalamud.dll</HintPath>
       <HintPath Condition="Exists('..\Dalamud\Dalamud\bin\Debug')">..\Dalamud\Dalamud\bin\Debug\Dalamud.dll</HintPath>
       <HintPath Condition="Exists('..\..\Dalamud\Dalamud\bin\Debug')">..\..\Dalamud\Dalamud\bin\Debug\Dalamud.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="ImGui.NET">
-      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks')">$(AppData)\XIVLauncher\addon\Hooks\ImGui.NET.dll</HintPath>
+      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks\dev')" >$(AppData)\XIVLauncher\addon\Hooks\dev\ImGui.NET.dll</HintPath>
       <HintPath Condition="Exists('$(DalamudHooks)')">$(DalamudHooks)\ImGuiScene.dll</HintPath>
       <HintPath Condition="Exists('..\Dalamud\Dalamud\bin\Debug')">..\Dalamud\Dalamud\bin\Debug\ImGui.NET.dll</HintPath>
       <HintPath Condition="Exists('..\..\Dalamud\Dalamud\bin\Debug')">..\..\Dalamud\Dalamud\bin\Debug\ImGui.NET.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="ImGuiScene">
-      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks')">$(AppData)\XIVLauncher\addon\Hooks\ImGuiScene.dll</HintPath>
+      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks\dev')" >$(AppData)\XIVLauncher\addon\Hooks\dev\ImGuiScene.dll</HintPath>
       <HintPath Condition="Exists('$(DalamudHooks)')">$(DalamudHooks)\ImGuiScene.dll</HintPath>
       <HintPath Condition="Exists('..\Dalamud\Dalamud\bin\Debug')">..\Dalamud\Dalamud\bin\Debug\ImGuiScene.dll</HintPath>
       <HintPath Condition="Exists('..\..\Dalamud\Dalamud\bin\Debug')">..\..\Dalamud\Dalamud\bin\Debug\ImGuiScene.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Lumina">
-      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks')">$(AppData)\XIVLauncher\addon\Hooks\Lumina.dll</HintPath>
+      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks\dev')" >$(AppData)\XIVLauncher\addon\Hooks\dev\Lumina.dll</HintPath>
       <HintPath Condition="Exists('$(DalamudHooks)')">$(DalamudHooks)\Lumina.dll</HintPath>
       <HintPath Condition="Exists('..\Dalamud\Dalamud\bin\Debug')">..\Dalamud\Dalamud\bin\Debug\Lumina.dll</HintPath>
       <HintPath Condition="Exists('..\..\Dalamud\Dalamud\bin\Debug')">..\..\Dalamud\Dalamud\bin\Debug\Lumina.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Lumina.Excel">
-      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks')">$(AppData)\XIVLauncher\addon\Hooks\Lumina.Excel.dll</HintPath>
+      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks\dev')" >$(AppData)\XIVLauncher\addon\Hooks\dev\Lumina.Excel.dll</HintPath>
       <HintPath Condition="Exists('$(DalamudHooks)')">$(DalamudHooks)\Lumina.Excel.dll</HintPath>
       <HintPath Condition="Exists('..\Dalamud\Dalamud\bin\Debug')">..\Dalamud\Dalamud\bin\Debug\Lumina.Excel.dll</HintPath>
       <HintPath Condition="Exists('..\..\Dalamud\Dalamud\bin\Debug')">..\..\Dalamud\Dalamud\bin\Debug\Lumina.Excel.dll</HintPath>
@@ -62,7 +62,7 @@
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json">
-      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks')">$(AppData)\XIVLauncher\addon\Hooks\Newtonsoft.Json.dll</HintPath>
+      <HintPath Condition="Exists('$(AppData)\XIVLauncher\addon\Hooks\dev')" >$(AppData)\XIVLauncher\addon\Hooks\dev\Newtonsoft.Json.dll</HintPath>
       <HintPath Condition="Exists('$(DalamudHooks)')">$(DalamudHooks)\Newtonsoft.Json.dll</HintPath>
       <HintPath Condition="Exists('..\Dalamud\Dalamud\bin\Debug')">..\Dalamud\Dalamud\bin\Debug\Newtonsoft.Json.dll</HintPath>
       <HintPath Condition="Exists('..\..\Dalamud\Dalamud\bin\Debug')">..\..\Dalamud\Dalamud\bin\Debug\Newtonsoft.Json.dll</HintPath>

--- a/Dalamud.DiscordBridge/Dalamud.DiscordBridge.csproj
+++ b/Dalamud.DiscordBridge/Dalamud.DiscordBridge.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>1.0.1.0</FileVersion>
-    <Version>1.0.1.0</Version>
+    <AssemblyVersion>1.0.1.1</AssemblyVersion>
+    <FileVersion>1.0.1.1</FileVersion>
+    <Version>1.0.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Dalamud.DiscordBridge/Dalamud.DiscordBridge.json
+++ b/Dalamud.DiscordBridge/Dalamud.DiscordBridge.json
@@ -1,12 +1,11 @@
 {
-  "Author": "goat",
+  "Author": "goat, modded by Franz",
   "Name": "Discord Chat Bridge",
-  "Description": "This plugin allows you to receive your chat messages inside of discord and chat on FFXIV remotely.",
+  "Description": "This plugin allows you to receive your chat messages inside of discord.",
   "InternalName": "Dalamud.DiscordBridge",
-  "AssemblyVersion": "1.0.0.2",
+  "AssemblyVersion": "1.0.1.0",
   "RepoUrl": "https://github.com/goaaats/Dalamud.DiscordBridge",
   "ApplicableVersion": "any",
-  "DalamudApplicableVersion": ">=4.9.8.3",
   "DalamudApiLevel": "2",
   "Tags": ["discord", "chat"]
 }

--- a/Dalamud.DiscordBridge/Dalamud.DiscordBridge.json
+++ b/Dalamud.DiscordBridge/Dalamud.DiscordBridge.json
@@ -3,9 +3,9 @@
   "Name": "Discord Chat Bridge",
   "Description": "This plugin allows you to receive your chat messages inside of discord.",
   "InternalName": "Dalamud.DiscordBridge",
-  "AssemblyVersion": "1.0.1.1",
+  "AssemblyVersion": "1.1.0.0",
   "RepoUrl": "https://github.com/goaaats/Dalamud.DiscordBridge",
   "ApplicableVersion": "any",
-  "DalamudApiLevel": "2",
+  "DalamudApiLevel": "3",
   "Tags": ["discord", "chat"]
 }

--- a/Dalamud.DiscordBridge/Dalamud.DiscordBridge.json
+++ b/Dalamud.DiscordBridge/Dalamud.DiscordBridge.json
@@ -3,7 +3,7 @@
   "Name": "Discord Chat Bridge",
   "Description": "This plugin allows you to receive your chat messages inside of discord.",
   "InternalName": "Dalamud.DiscordBridge",
-  "AssemblyVersion": "1.0.1.0",
+  "AssemblyVersion": "1.0.1.1",
   "RepoUrl": "https://github.com/goaaats/Dalamud.DiscordBridge",
   "ApplicableVersion": "any",
   "DalamudApiLevel": "2",

--- a/Dalamud.DiscordBridge/Dalamud.DiscordBridge.json
+++ b/Dalamud.DiscordBridge/Dalamud.DiscordBridge.json
@@ -3,8 +3,8 @@
   "Name": "Discord Chat Bridge",
   "Description": "This plugin allows you to receive your chat messages inside of discord.",
   "InternalName": "Dalamud.DiscordBridge",
-  "AssemblyVersion": "1.1.0.0",
-  "RepoUrl": "https://github.com/goaaats/Dalamud.DiscordBridge",
+  "AssemblyVersion": "1.1.0.1",
+  "RepoUrl": "https://github.com/reiichi001/Dalamud.DiscordBridge",
   "ApplicableVersion": "any",
   "DalamudApiLevel": "3",
   "Tags": ["discord", "chat"]

--- a/Dalamud.DiscordBridge/DalamudPackager.targets
+++ b/Dalamud.DiscordBridge/DalamudPackager.targets
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project>
+    <Target Name="PackagePlugin" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
+        <DalamudPackager
+                ProjectDir="$(ProjectDir)"
+                OutputPath="$(OutputPath)"
+                AssemblyName="$(AssemblyName)"
+                MakeZip="true"/>
+    </Target>
+</Project>

--- a/Dalamud.DiscordBridge/DiscordHandler.cs
+++ b/Dalamud.DiscordBridge/DiscordHandler.cs
@@ -200,7 +200,7 @@ namespace Dalamud.DiscordBridge
                     this.plugin.Config.Save();
 
                     await SendGenericEmbed(message.Channel,
-                        $"OK! This channel has been set to receive the following chat kinds:\n\n```{config.ChatTypes.Select(x => $"{x.GetFancyName()}").Aggregate((x, y) => x + "\n" + y)}```",
+                        $"OK! This channel has been set to receive the following chat kinds:\n\n```\n{config.ChatTypes.Select(x => $"{x.GetFancyName()}").Aggregate((x, y) => x + "\n" + y)}```",
                         "Chat kinds set", EmbedColorFine);
 
                     return;
@@ -251,9 +251,15 @@ namespace Dalamud.DiscordBridge
                     this.plugin.Config.ChannelConfigs[message.Channel.Id] = config;
                     this.plugin.Config.Save();
 
+                    if (config.ChatTypes.Count() == 0)
+                    {
+                        await SendGenericEmbed(message.Channel,
+                        $"All chat kinds have been removed from this channel.",
+                        "Chat Kinds unset", EmbedColorFine);
+                    }
                     await SendGenericEmbed(message.Channel,
-                        $"OK! This channel has been set to receive the following chat kinds:\n\n```{config.ChatTypes.Select(x => $"{x.GetSlug()} - {x.GetFancyName()}").Aggregate((x, y) => x + "\n" + y)}```",
-                        "Chat kinds set", EmbedColorFine);
+                        $"OK! This channel will still receive the following chat kinds:\n\n```\n{config.ChatTypes.Select(x => $"{x.GetSlug()} - {x.GetFancyName()}").Aggregate((x, y) => x + "\n" + y)}```",
+                        "Chat kinds unset", EmbedColorFine);
 
                     return;
                 }
@@ -295,8 +301,9 @@ namespace Dalamud.DiscordBridge
 
                     this.plugin.Config.Save();
 
+
                     await SendGenericEmbed(message.Channel,
-                        $"OK! The following prefixes are set:\n\n```{this.plugin.Config.PrefixConfigs.Select(x => $"{x.Key.GetFancyName()} - {x.Value}").Aggregate((x, y) => x + "\n" + y)}```",
+                        $"OK! The following prefixes are set:\n\n```\n{this.plugin.Config.PrefixConfigs.Select(x => $"{x.Key.GetFancyName()} - {x.Value}").Aggregate((x, y) => x + "\n" + y)}```",
                         "Prefix set", EmbedColorFine);
 
                     return;
@@ -346,7 +353,7 @@ namespace Dalamud.DiscordBridge
                     {
                         await SendGenericEmbed(message.Channel,
                         $"OK! The prefix for {XivChatTypeExtensions.GetBySlug(args[2])} has been removed.\n\n"
-                        + $"The following prefixes are still set:\n\n```{this.plugin.Config.PrefixConfigs.Select(x => $"{x.Key.GetFancyName()} - {x.Value}").Aggregate((x, y) => x + "\n" + y)}```",
+                        + $"The following prefixes are still set:\n\n```\n{this.plugin.Config.PrefixConfigs.Select(x => $"{x.Key.GetFancyName()} - {x.Value}").Aggregate((x, y) => x + "\n" + y)}```",
                         "Prefix unset", EmbedColorFine);
                     }
 
@@ -383,7 +390,7 @@ namespace Dalamud.DiscordBridge
                     }
 
                     await SendGenericEmbed(message.Channel,
-                        $"OK! This channel has been set to receive the following chat kinds:\n\n```{config.ChatTypes.Select(x => $"{x.GetFancyName()}").Aggregate((x, y) => x + "\n" + y)}```",
+                        $"OK! This channel has been set to receive the following chat kinds:\n\n```\n{config.ChatTypes.Select(x => $"{x.GetFancyName()}").Aggregate((x, y) => x + "\n" + y)}```",
                         "Chat kinds set", EmbedColorFine);
 
                     return;

--- a/Dalamud.DiscordBridge/DiscordHandler.cs
+++ b/Dalamud.DiscordBridge/DiscordHandler.cs
@@ -569,6 +569,8 @@ namespace Dalamud.DiscordBridge
                         break;
                     case (XivChatType)61: // npc talk
                         break;
+                    case (XivChatType)68: // npc announce
+                        break;
                     default:
                         avatarUrl = (await XivApiClient.GetCharacterSearch(senderName, senderWorld)).AvatarUrl;
                         break;

--- a/Dalamud.DiscordBridge/DiscordHandler.cs
+++ b/Dalamud.DiscordBridge/DiscordHandler.cs
@@ -8,10 +8,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Dalamud.DiscordBridge.Model;
 using Dalamud.DiscordBridge.XivApi;
-using Dalamud.Game.Chat;
+using Dalamud.Game.Text;
 using Dalamud.Plugin;
 using Discord;
-using Discord.Net.Providers.WS4Net;
 using Discord.Rest;
 using Discord.Webhook;
 using Discord.WebSocket;
@@ -96,7 +95,6 @@ namespace Dalamud.DiscordBridge
 
             this.socketClient = new DiscordSocketClient(new DiscordSocketConfig
             {
-                WebSocketProvider = WS4NetProvider.Instance,
                 MessageCacheSize = 20, // hold onto the last 20 messages per channel in cache for duplicate checks
             });
             this.socketClient.Ready += SocketClientOnReady;

--- a/Dalamud.DiscordBridge/DiscordHandler.cs
+++ b/Dalamud.DiscordBridge/DiscordHandler.cs
@@ -599,7 +599,7 @@ namespace Dalamud.DiscordBridge
                 if (recentMsg != null)
                 {
                     long msgDiff = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - recentMsg.Timestamp.ToUnixTimeMilliseconds();
-                    PluginLog.Information($"[IN TESTING]\n DIFF:{msgDiff} Skipping duplicate message: {messageContent}");
+                    PluginLog.Log($"[IN TESTING]\n DIFF:{msgDiff} Skipping duplicate message: {messageContent}");
                     if (msgDiff < this.plugin.Config.DuplicateCheckMS)
                         return;
                 }

--- a/Dalamud.DiscordBridge/DiscordHandler.cs
+++ b/Dalamud.DiscordBridge/DiscordHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Configuration;
@@ -536,7 +536,8 @@ namespace Dalamud.DiscordBridge
             var avatarUrl = Constant.LogoLink;
             try
             {
-                avatarUrl = (await XivApiClient.GetCharacterSearch(senderName, senderWorld)).AvatarUrl;
+                if (chatType != XivChatType.Echo)
+                    avatarUrl = (await XivApiClient.GetCharacterSearch(senderName, senderWorld)).AvatarUrl;
             }
             catch (Exception ex)
             {

--- a/Dalamud.DiscordBridge/DiscordHandler.cs
+++ b/Dalamud.DiscordBridge/DiscordHandler.cs
@@ -11,6 +11,7 @@ using Dalamud.DiscordBridge.XivApi;
 using Dalamud.Game.Chat;
 using Dalamud.Plugin;
 using Discord;
+using Discord.Net.Providers.WS4Net;
 using Discord.Rest;
 using Discord.Webhook;
 using Discord.WebSocket;
@@ -92,7 +93,10 @@ namespace Dalamud.DiscordBridge
 
             this.MessageQueue = new DiscordMessageQueue(this.plugin);
 
-            this.socketClient = new DiscordSocketClient();
+            this.socketClient = new DiscordSocketClient(new DiscordSocketConfig
+            {
+                WebSocketProvider = WS4NetProvider.Instance,
+            });
             this.socketClient.Ready += SocketClientOnReady;
             this.socketClient.MessageReceived += SocketClientOnMessageReceived;
         }

--- a/Dalamud.DiscordBridge/DiscordHandler.cs
+++ b/Dalamud.DiscordBridge/DiscordHandler.cs
@@ -68,6 +68,7 @@ namespace Dalamud.DiscordBridge
             XivChatType.CrossLinkShell7,
             XivChatType.CrossLinkShell8,
             XivChatType.Echo,
+            XivChatType.SystemMessage,
         };
 
         /// <summary>

--- a/Dalamud.DiscordBridge/DiscordHandler.cs
+++ b/Dalamud.DiscordBridge/DiscordHandler.cs
@@ -596,12 +596,16 @@ namespace Dalamud.DiscordBridge
                 var recentMsg = recentMessages.FirstOrDefault(msg => msg.Content == messageContent);
 
                 
-                if (recentMsg != null)
+                if (this.plugin.Config.DuplicateCheckMS > 0 && recentMsg != null)
                 {
                     long msgDiff = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - recentMsg.Timestamp.ToUnixTimeMilliseconds();
-                    PluginLog.Log($"[IN TESTING]\n DIFF:{msgDiff} Skipping duplicate message: {messageContent}");
+                    
                     if (msgDiff < this.plugin.Config.DuplicateCheckMS)
+                    {
+                        PluginLog.Log($"[IN TESTING]\n DIFF:{msgDiff}ms Skipping duplicate message: {messageContent}");
                         return;
+                    }
+                        
                 }
 
                 await webhookClient.SendMessageAsync(messageContent,

--- a/Dalamud.DiscordBridge/DiscordHandler.cs
+++ b/Dalamud.DiscordBridge/DiscordHandler.cs
@@ -563,8 +563,16 @@ namespace Dalamud.DiscordBridge
             var avatarUrl = Constant.LogoLink;
             try
             {
-                if (chatType != XivChatType.Echo)
-                    avatarUrl = (await XivApiClient.GetCharacterSearch(senderName, senderWorld)).AvatarUrl;
+                switch (chatType)
+                {
+                    case XivChatType.Echo:
+                        break;
+                    case (XivChatType)61: // npc talk
+                        break;
+                    default:
+                        avatarUrl = (await XivApiClient.GetCharacterSearch(senderName, senderWorld)).AvatarUrl;
+                        break;
+                }                    
             }
             catch (Exception ex)
             {

--- a/Dalamud.DiscordBridge/DiscordHandler.cs
+++ b/Dalamud.DiscordBridge/DiscordHandler.cs
@@ -397,17 +397,17 @@ namespace Dalamud.DiscordBridge
                         .WithTitle("Discord Bridge Help")
                         .WithDescription("You can use the following commands to set up the Discord bridge.")
                         .WithColor(new Color(EmbedColorFine))
-                        .AddField("!setchannel", "Select, which kinds of chat should arrive in this channel.\n" +
-                                                 "Format: ``!setchannel <kind1,kind2,...>``\n\n" +
+                        .AddField($"{this.plugin.Config.DiscordBotPrefix}setchannel", "Select, which kinds of chat should arrive in this channel.\n" +
+                                                 $"Format: ``{this.plugin.Config.DiscordBotPrefix}setchannel <kind1,kind2,...>``\n\n" +
                                                  $"See [this link for a list of all available chat kinds]({Constant.KindListLink}) or type ``any`` to enable it for all regular chat messages.")
                         //$"The following chat kinds are available:\n```all - All regular chat\n{XivChatTypeExtensions.TypeInfoDict.Select(x => $"{x.Value.Slug} - {x.Value.FancyName}").Aggregate((x, y) => x + "\n" + y)}```")
-                        .AddField("!unsetchannel", "Works like the previous command, but removes kinds of chat from the list of kinds that are sent to this channel.")
-                        .AddField("!listchannel", "List all chat kinds that are sent to this channel.")
-                        .AddField("!toggledf", "Enable or disable sending duty finder updates to this channel.")
-                        .AddField("!setprefix", "Set a prefix for chat kinds. This can be an emoji or a string that will be prepended to every chat message that will arrive with this chat kind.\n" +
-                                                "Format: ``!setchannel <kind1,kind2,...> <prefix>``")
-                        .AddField("!unsetprefix", "Remove prefix set for a chat kind. \n"
-                        + "Format: ``!unsetprefix <kind>``")
+                        .AddField($"{this.plugin.Config.DiscordBotPrefix}unsetchannel", "Works like the previous command, but removes kinds of chat from the list of kinds that are sent to this channel.")
+                        .AddField($"{this.plugin.Config.DiscordBotPrefix}listchannel", "List all chat kinds that are sent to this channel.")
+                        .AddField($"{this.plugin.Config.DiscordBotPrefix}toggledf", "Enable or disable sending duty finder updates to this channel.")
+                        .AddField($"{this.plugin.Config.DiscordBotPrefix}setprefix", "Set a prefix for chat kinds. This can be an emoji or a string that will be prepended to every chat message that will arrive with this chat kind.\n" +
+                                                $"Format: ``{this.plugin.Config.DiscordBotPrefix}setchannel <kind1,kind2,...> <prefix>``")
+                        .AddField($"{this.plugin.Config.DiscordBotPrefix}unsetprefix", "Remove prefix set for a chat kind. \n"
+                        + $"Format: ``{this.plugin.Config.DiscordBotPrefix}unsetprefix <kind>``")
                         .AddField("Need more help?",
                             $"You can [read the full step-by-step guide]({Constant.HelpLink}) or [join our Discord server]({Constant.DiscordJoinLink}) to ask for help.")
                         .WithFooter(footer =>

--- a/Dalamud.DiscordBridge/DiscordHandler.cs
+++ b/Dalamud.DiscordBridge/DiscordHandler.cs
@@ -541,7 +541,7 @@ namespace Dalamud.DiscordBridge
             }
             catch (Exception ex)
             {
-                PluginLog.Error(ex, "Cannot fetch XIVAPI character search.");
+                PluginLog.Error(ex, $"Cannot fetch XIVAPI character search for {senderName} on {senderWorld}");
             }
 
             var displayName = senderName + (string.IsNullOrEmpty(senderWorld) || string.IsNullOrEmpty(senderName)

--- a/Dalamud.DiscordBridge/DiscordMessageQueue.cs
+++ b/Dalamud.DiscordBridge/DiscordMessageQueue.cs
@@ -177,6 +177,9 @@ namespace Dalamud.DiscordBridge
                                                 case XivChatType.StandardEmote:
                                                     // we need to get the world here because cross-world people will be assumed local player's otherwise.
                                                     senderWorld = chatEvent.Message.TextValue.TrimStart(senderName.ToCharArray()).Split(' ')[0];
+                                                    if (senderWorld.EndsWith("'s")) // fuck having to do this
+                                                        senderWorld = senderWorld.Substring(0, senderWorld.Length - 2);
+
                                                     break;
                                                 case XivChatType.Echo:
                                                     senderName = this.plugin.Interface.ClientState.LocalPlayer.Name;

--- a/Dalamud.DiscordBridge/DiscordMessageQueue.cs
+++ b/Dalamud.DiscordBridge/DiscordMessageQueue.cs
@@ -96,6 +96,16 @@ namespace Dalamud.DiscordBridge
                                     }
                                     else
                                     {
+
+                                        // XIVAPI wants these padded with 0s in the front if under 6 digits
+                                        // at least if Titanium Ore testing is to be believed. 
+                                        var iconFolder = $"{itemLink.Item.Icon / 1000 * 1000}".PadLeft(6,'0');
+                                        var iconFile = $"{itemLink.Item.Icon}".PadLeft(6, '0');
+
+                                        avatarUrl = $"https://xivapi.com" + $"/i/{iconFolder}/{iconFile}.png";
+                                        /* 
+                                        // we don't need this anymore because the above should work
+                                        // but it doesn't hurt to have it commented out as a fallback for the future
                                         try
                                         {
                                             ItemResult res = XivApiClient.GetItem(itemLink.Item.RowId).GetAwaiter().GetResult();
@@ -105,6 +115,7 @@ namespace Dalamud.DiscordBridge
                                         {
                                             PluginLog.Error(ex, "Cannot fetch XIVAPI item search.");
                                         }
+                                        */
                                     }
 
                                     //var valueInfo = matchInfo.Groups["value"];

--- a/Dalamud.DiscordBridge/DiscordMessageQueue.cs
+++ b/Dalamud.DiscordBridge/DiscordMessageQueue.cs
@@ -175,29 +175,25 @@ namespace Dalamud.DiscordBridge
                                                     // senderWorld = this.plugin.Interface.ClientState.LocalPlayer.HomeWorld.GameData.Name;
                                                     break;
                                                 case XivChatType.StandardEmote:
+                                                    playerLink = chatEvent.Message.Payloads.FirstOrDefault(x => x.Type == PayloadType.Player) as PlayerPayload;
+                                                    senderName = playerLink.PlayerName;
+                                                    senderWorld = playerLink.World.Name;
                                                     // we need to get the world here because cross-world people will be assumed local player's otherwise.
+                                                    /*
                                                     senderWorld = chatEvent.Message.TextValue.TrimStart(senderName.ToCharArray()).Split(' ')[0];
                                                     if (senderWorld.EndsWith("'s")) // fuck having to do this
                                                         senderWorld = senderWorld.Substring(0, senderWorld.Length - 2);
-
+                                                    */
                                                     break;
                                                 case XivChatType.Echo:
                                                     senderName = this.plugin.Interface.ClientState.LocalPlayer.Name;
                                                     // senderWorld = this.plugin.Interface.ClientState.LocalPlayer.HomeWorld.GameData.Name;
                                                     break;
-                                                case XivChatType.SystemMessage:
-                                                    break;
-                                                case XivChatType.SystemError:
-                                                    break;
-                                                case XivChatType.GatheringSystemMessage:
-                                                    break;
-                                                case XivChatType.ErrorMessage:
-                                                    break;
-                                                case (XivChatType)61: // retainerspeak
-                                                    break;
-                                                case (XivChatType)68: // battle NPCs
-                                                    break;
                                                 default:
+                                                    if ((int)chatEvent.ChatType >= 41 && (int)chatEvent.ChatType <= 55) //ignore a bunch of non-chat messages
+                                                        break;
+                                                    if ((int)chatEvent.ChatType >= 58 && (int)chatEvent.ChatType <= 70) //ignore a bunch of non-chat messages
+                                                        break;
                                                     if ((int)chatEvent.ChatType > 107) // don't handle anything past CWLS8 for now
                                                         break;
                                                     PluginLog.Error("playerLink was null. Sender: {0}",

--- a/Dalamud.DiscordBridge/DiscordMessageQueue.cs
+++ b/Dalamud.DiscordBridge/DiscordMessageQueue.cs
@@ -204,11 +204,13 @@ namespace Dalamud.DiscordBridge
                                                 default:
                                                     if ((int)chatEvent.ChatType >= 41 && (int)chatEvent.ChatType <= 55) //ignore a bunch of non-chat messages
                                                         break;
-                                                    if ((int)chatEvent.ChatType >= 58 && (int)chatEvent.ChatType <= 70) //ignore a bunch of non-chat messages
+                                                    if ((int)chatEvent.ChatType >= 57 && (int)chatEvent.ChatType <= 70) //ignore a bunch of non-chat messages
+                                                        break;
+                                                    if ((int)chatEvent.ChatType >= 72 && (int)chatEvent.ChatType <= 100) // ignore a bunch of non-chat messages
                                                         break;
                                                     if ((int)chatEvent.ChatType > 107) // don't handle anything past CWLS8 for now
                                                         break;
-                                                    PluginLog.Error($"playerLink was null.\nChatType: {chatEvent.ChatType} Sender: {chatEvent.Sender.TextValue} Message: {chatEvent.Message.TextValue}");
+                                                    PluginLog.Error($"playerLink was null.\nChatType: {chatEvent.ChatType} ({(int)chatEvent.ChatType}) Sender: {chatEvent.Sender.TextValue} Message: {chatEvent.Message.TextValue}");
                                                     senderName = chatEvent.Sender.TextValue;
                                                     break;
                                             }

--- a/Dalamud.DiscordBridge/DiscordMessageQueue.cs
+++ b/Dalamud.DiscordBridge/DiscordMessageQueue.cs
@@ -138,6 +138,16 @@ namespace Dalamud.DiscordBridge
                                             // Franz is really tired of getting playerlink is null when there shouldn't be a player link for certain things
                                             switch (chatEvent.ChatType)
                                             {
+                                                case XivChatType.Debug:
+                                                    break;
+                                                case XivChatType.Urgent:
+                                                    break;
+                                                case XivChatType.Notice:
+                                                    break;
+                                                case XivChatType.TellOutgoing:
+                                                    senderName = this.plugin.Interface.ClientState.LocalPlayer.Name;
+                                                    // senderWorld = this.plugin.Interface.ClientState.LocalPlayer.HomeWorld.GameData.Name;
+                                                    break;
                                                 case XivChatType.Echo:
                                                     senderName = this.plugin.Interface.ClientState.LocalPlayer.Name;
                                                     // senderWorld = this.plugin.Interface.ClientState.LocalPlayer.HomeWorld.GameData.Name;
@@ -146,16 +156,15 @@ namespace Dalamud.DiscordBridge
                                                     break;
                                                 case XivChatType.SystemError:
                                                     break;
-                                                case XivChatType.Debug:
+                                                case XivChatType.GatheringSystemMessage:
                                                     break;
-                                                case XivChatType.TellOutgoing:
-                                                    senderName = this.plugin.Interface.ClientState.LocalPlayer.Name;
-                                                    // senderWorld = this.plugin.Interface.ClientState.LocalPlayer.HomeWorld.GameData.Name;
+                                                case XivChatType.ErrorMessage:
                                                     break;
+                                                
                                                 case (XivChatType)61: // retainerspeak
                                                     break;
                                                 default:
-                                                    if ((int)chatEvent.ChatType > 80) // stfu rando types
+                                                    if ((int)chatEvent.ChatType > 107) // don't handle anything past CWLS8 for now
                                                         break;
                                                     PluginLog.Error("playerLink was null. Sender: {0}",
                                                         BitConverter.ToString(chatEvent.Sender.Encode()));

--- a/Dalamud.DiscordBridge/DiscordMessageQueue.cs
+++ b/Dalamud.DiscordBridge/DiscordMessageQueue.cs
@@ -141,6 +141,10 @@ namespace Dalamud.DiscordBridge
                                 : chatEvent.Sender.ToString();
                             var senderWorld = string.Empty;
 
+                            // for debugging. Make sure to comment this out for releases.
+                            PluginLog.Debug($"Type: {chatEvent.ChatType} Sender: {chatEvent.Sender.TextValue} "
+                                                        + $"Message: {chatEvent.Message.TextValue}");
+
                             try
                             {
                                 if (this.plugin.Interface.ClientState.LocalPlayer != null)
@@ -189,6 +193,10 @@ namespace Dalamud.DiscordBridge
                                                     senderName = this.plugin.Interface.ClientState.LocalPlayer.Name;
                                                     // senderWorld = this.plugin.Interface.ClientState.LocalPlayer.HomeWorld.GameData.Name;
                                                     break;
+                                                case (XivChatType)61: // NPC Talk
+                                                    senderName = chatEvent.Sender.TextValue;
+                                                    senderWorld = "NPC";
+                                                    break;
                                                 default:
                                                     if ((int)chatEvent.ChatType >= 41 && (int)chatEvent.ChatType <= 55) //ignore a bunch of non-chat messages
                                                         break;
@@ -196,11 +204,8 @@ namespace Dalamud.DiscordBridge
                                                         break;
                                                     if ((int)chatEvent.ChatType > 107) // don't handle anything past CWLS8 for now
                                                         break;
-                                                    PluginLog.Error("playerLink was null. Sender: {0}",
-                                                        BitConverter.ToString(chatEvent.Sender.Encode()));
+                                                    PluginLog.Error($"playerLink was null.\nChatType: {chatEvent.ChatType} Sender: {chatEvent.Sender.TextValue} Message: {chatEvent.Message.TextValue}");
                                                     senderName = chatEvent.Sender.TextValue;
-                                                    PluginLog.Information($"Type: {chatEvent.ChatType} Sender: {chatEvent.Sender.TextValue} "
-                                                        + $"Message: {chatEvent.Message.TextValue}");
                                                     break;
                                             }
                                             

--- a/Dalamud.DiscordBridge/DiscordMessageQueue.cs
+++ b/Dalamud.DiscordBridge/DiscordMessageQueue.cs
@@ -135,8 +135,36 @@ namespace Dalamud.DiscordBridge
                                         }
                                         else
                                         {
-                                            PluginLog.Error("playerLink was null. Sender: {0}",
-                                                BitConverter.ToString(chatEvent.Sender.Encode()));
+                                            // Franz is really tired of getting playerlink is null when there shouldn't be a player link for certain things
+                                            switch (chatEvent.ChatType)
+                                            {
+                                                case XivChatType.Echo:
+                                                    senderName = this.plugin.Interface.ClientState.LocalPlayer.Name;
+                                                    // senderWorld = this.plugin.Interface.ClientState.LocalPlayer.HomeWorld.GameData.Name;
+                                                    break;
+                                                case XivChatType.SystemMessage:
+                                                    break;
+                                                case XivChatType.SystemError:
+                                                    break;
+                                                case XivChatType.Debug:
+                                                    break;
+                                                case XivChatType.TellOutgoing:
+                                                    senderName = this.plugin.Interface.ClientState.LocalPlayer.Name;
+                                                    // senderWorld = this.plugin.Interface.ClientState.LocalPlayer.HomeWorld.GameData.Name;
+                                                    break;
+                                                case (XivChatType)61: // retainerspeak
+                                                    break;
+                                                default:
+                                                    if ((int)chatEvent.ChatType > 80) // stfu rando types
+                                                        break;
+                                                    PluginLog.Error("playerLink was null. Sender: {0}",
+                                                        BitConverter.ToString(chatEvent.Sender.Encode()));
+                                                    senderName = chatEvent.Sender.TextValue;
+                                                    PluginLog.Information($"Type: {chatEvent.ChatType} Sender: {chatEvent.Sender.TextValue} "
+                                                        + $"Message: {chatEvent.Message.TextValue}");
+                                                    break;
+                                            }
+                                            
 
                                             senderName = chatEvent.ChatType == XivChatType.TellOutgoing
                                                 ? this.plugin.Interface.ClientState.LocalPlayer.Name
@@ -145,13 +173,17 @@ namespace Dalamud.DiscordBridge
 
                                         senderWorld = this.plugin.Interface.ClientState.LocalPlayer.HomeWorld.GameData
                                             .Name;
+                                        // PluginLog.Information($"Playerlink is null: {senderWorld}");
                                     }
                                     else
                                     {
                                         senderName = chatEvent.ChatType == XivChatType.TellOutgoing
                                             ? this.plugin.Interface.ClientState.LocalPlayer.Name
                                             : playerLink.PlayerName;
-                                        senderWorld = playerLink.World.Name;
+                                        senderWorld = chatEvent.ChatType == XivChatType.TellOutgoing
+                                            ? this.plugin.Interface.ClientState.LocalPlayer.HomeWorld.GameData.Name
+                                            : playerLink.World.Name;
+                                        // PluginLog.Information($"Playerlink was not null: {senderWorld}");
                                     }
                                 }
                                 else

--- a/Dalamud.DiscordBridge/DiscordMessageQueue.cs
+++ b/Dalamud.DiscordBridge/DiscordMessageQueue.cs
@@ -8,9 +8,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Dalamud.DiscordBridge.Model;
 using Dalamud.DiscordBridge.XivApi;
-using Dalamud.Game.Chat;
-using Dalamud.Game.Chat.SeStringHandling;
-using Dalamud.Game.Chat.SeStringHandling.Payloads;
+using Dalamud.Game.Text;
+using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Plugin;
 
 namespace Dalamud.DiscordBridge

--- a/Dalamud.DiscordBridge/DiscordMessageQueue.cs
+++ b/Dalamud.DiscordBridge/DiscordMessageQueue.cs
@@ -174,6 +174,10 @@ namespace Dalamud.DiscordBridge
                                                     senderName = this.plugin.Interface.ClientState.LocalPlayer.Name;
                                                     // senderWorld = this.plugin.Interface.ClientState.LocalPlayer.HomeWorld.GameData.Name;
                                                     break;
+                                                case XivChatType.StandardEmote:
+                                                    // we need to get the world here because cross-world people will be assumed local player's otherwise.
+                                                    senderWorld = chatEvent.Message.TextValue.TrimStart(senderName.ToCharArray()).Split(' ')[0];
+                                                    break;
                                                 case XivChatType.Echo:
                                                     senderName = this.plugin.Interface.ClientState.LocalPlayer.Name;
                                                     // senderWorld = this.plugin.Interface.ClientState.LocalPlayer.HomeWorld.GameData.Name;
@@ -202,14 +206,14 @@ namespace Dalamud.DiscordBridge
                                             }
                                             
 
-                                            senderName = chatEvent.ChatType == XivChatType.TellOutgoing
-                                                ? this.plugin.Interface.ClientState.LocalPlayer.Name
-                                                : chatEvent.Sender.TextValue;
+                                            
                                         }
 
-                                        senderWorld = this.plugin.Interface.ClientState.LocalPlayer.HomeWorld.GameData
-                                            .Name;
-                                        // PluginLog.Information($"Playerlink is null: {senderWorld}");
+                                        // only if we still need one
+                                        if (senderWorld.Equals(string.Empty))
+                                            senderWorld = this.plugin.Interface.ClientState.LocalPlayer.HomeWorld.GameData.Name;
+
+                                        // PluginLog.Information($"FRANZDEBUGGINGNULL Playerlink is null: {senderName}@{senderWorld}");
                                     }
                                     else
                                     {
@@ -219,7 +223,7 @@ namespace Dalamud.DiscordBridge
                                         senderWorld = chatEvent.ChatType == XivChatType.TellOutgoing
                                             ? this.plugin.Interface.ClientState.LocalPlayer.HomeWorld.GameData.Name
                                             : playerLink.World.Name;
-                                        // PluginLog.Information($"Playerlink was not null: {senderWorld}");
+                                        // PluginLog.Information($"FRANZDEBUGGING Playerlink was not null: {senderName}@{senderWorld}");
                                     }
                                 }
                                 else

--- a/Dalamud.DiscordBridge/DiscordMessageQueue.cs
+++ b/Dalamud.DiscordBridge/DiscordMessageQueue.cs
@@ -160,8 +160,9 @@ namespace Dalamud.DiscordBridge
                                                     break;
                                                 case XivChatType.ErrorMessage:
                                                     break;
-                                                
                                                 case (XivChatType)61: // retainerspeak
+                                                    break;
+                                                case (XivChatType)68: // battle NPCs
                                                     break;
                                                 default:
                                                     if ((int)chatEvent.ChatType > 107) // don't handle anything past CWLS8 for now

--- a/Dalamud.DiscordBridge/DiscordMessageQueue.cs
+++ b/Dalamud.DiscordBridge/DiscordMessageQueue.cs
@@ -197,6 +197,10 @@ namespace Dalamud.DiscordBridge
                                                     senderName = chatEvent.Sender.TextValue;
                                                     senderWorld = "NPC";
                                                     break;
+                                                case (XivChatType)68: // NPC Announcement
+                                                    senderName = chatEvent.Sender.TextValue;
+                                                    senderWorld = "NPC";
+                                                    break;
                                                 default:
                                                     if ((int)chatEvent.ChatType >= 41 && (int)chatEvent.ChatType <= 55) //ignore a bunch of non-chat messages
                                                         break;

--- a/Dalamud.DiscordBridge/DiscordMessageQueue.cs
+++ b/Dalamud.DiscordBridge/DiscordMessageQueue.cs
@@ -87,10 +87,24 @@ namespace Dalamud.DiscordBridge
                                     var itemLink =
                                     retainerSaleEvent.Message.Payloads.First(x => x.Type == PayloadType.Item) as ItemPayload;
 
+                                    var avatarUrl = Constant.LogoLink;
+
                                     if (itemLink == null)
                                     {
                                         PluginLog.Error("itemLink was null. Msg: {0}", BitConverter.ToString(retainerSaleEvent.Message.Encode()));
                                         break;
+                                    }
+                                    else
+                                    {
+                                        try
+                                        {
+                                            ItemResult res = XivApiClient.GetItem(itemLink.Item.RowId).GetAwaiter().GetResult();
+                                            avatarUrl = $"https://xivapi.com{res.Icon}";
+                                        }
+                                        catch (Exception ex)
+                                        {
+                                            PluginLog.Error(ex, "Cannot fetch XIVAPI item search.");
+                                        }
                                     }
 
                                     //var valueInfo = matchInfo.Groups["value"];
@@ -99,7 +113,8 @@ namespace Dalamud.DiscordBridge
                                     //    continue;
 
                                     //SendItemSaleEvent(uint itemId, int amount, bool isHq, string message, XivChatType chatType)
-                                    await this.plugin.Discord.SendItemSaleEvent(itemLink.Item.RowId, 1, itemLink.IsHQ, retainerSaleEvent.Message.TextValue, retainerSaleEvent.ChatType);
+
+                                    await this.plugin.Discord.SendItemSaleEvent(itemLink.Item.Name, avatarUrl, itemLink.Item.RowId, retainerSaleEvent.Message.TextValue, retainerSaleEvent.ChatType);
                                 }
                             }
                             catch (Exception e)

--- a/Dalamud.DiscordBridge/DiscordMessageQueue.cs
+++ b/Dalamud.DiscordBridge/DiscordMessageQueue.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -110,7 +110,7 @@ namespace Dalamud.DiscordBridge
 
                         if (resultEvent is QueuedChatEvent chatEvent)
                         {
-                            var senderName = chatEvent.ChatType == XivChatType.TellOutgoing
+                            var senderName = (chatEvent.ChatType == XivChatType.TellOutgoing || chatEvent.ChatType == XivChatType.Echo)
                                 ? this.plugin.Interface.ClientState.LocalPlayer.Name
                                 : chatEvent.Sender.ToString();
                             var senderWorld = string.Empty;

--- a/Dalamud.DiscordBridge/Model/DiscordChannelConfig.cs
+++ b/Dalamud.DiscordBridge/Model/DiscordChannelConfig.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using Dalamud.Game.Chat;
+using Dalamud.Game.Text;
 
 namespace Dalamud.DiscordBridge.Model
 {

--- a/Dalamud.DiscordBridge/Model/QueuedChatEvent.cs
+++ b/Dalamud.DiscordBridge/Model/QueuedChatEvent.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Dalamud.DiscordBridge.XivApi;
-using Dalamud.Game.Chat;
-using Dalamud.Game.Chat.SeStringHandling;
+using Dalamud.Game.Text;
+using Dalamud.Game.Text.SeStringHandling;
 
 namespace Dalamud.DiscordBridge.Model
 {

--- a/Dalamud.DiscordBridge/Model/QueuedRetainerItemSaleEvent.cs
+++ b/Dalamud.DiscordBridge/Model/QueuedRetainerItemSaleEvent.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Dalamud.DiscordBridge.XivApi;
+using Dalamud.Game.Chat;
+using Dalamud.Game.Chat.SeStringHandling;
+
+namespace Dalamud.DiscordBridge.Model
+{
+    public class QueuedRetainerItemSaleEvent : QueuedXivEvent
+    {
+        public SeString Message { get; set; }
+        public SeString Sender { get; set; }
+        public XivChatType ChatType { get; set; }
+    }
+}

--- a/Dalamud.DiscordBridge/Model/QueuedRetainerItemSaleEvent.cs
+++ b/Dalamud.DiscordBridge/Model/QueuedRetainerItemSaleEvent.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Dalamud.DiscordBridge.XivApi;
-using Dalamud.Game.Chat;
-using Dalamud.Game.Chat.SeStringHandling;
+using Dalamud.Game.Text;
+using Dalamud.Game.Text.SeStringHandling;
 
 namespace Dalamud.DiscordBridge.Model
 {

--- a/Dalamud.DiscordBridge/Plugin.cs
+++ b/Dalamud.DiscordBridge/Plugin.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Dalamud.DiscordBridge.Attributes;
 using Dalamud.DiscordBridge.Model;
 using Dalamud.Game.Chat;
@@ -27,8 +29,26 @@ namespace Dalamud.DiscordBridge
             this.Config = (Configuration)this.Interface.GetPluginConfig() ?? new Configuration();
             this.Config.Initialize(this.Interface);
 
+            
+
             this.Discord = new DiscordHandler(this);
-            this.Discord.Start();
+            //Task t = this.Discord.Start();
+            Task.Run(async () =>
+            {
+                await this.Discord.Start();
+            });
+
+            // try to force-reload it
+            if (!this.Discord.IsConnected)
+            {
+                PluginLog.Information("Forcing DiscordBridge to run with Task.Run()");
+                this.Discord.Dispose();
+                this.Discord = new DiscordHandler(this);
+                Task.Run(async () =>
+                {
+                    await this.Discord.Start();
+                });
+            }
 
             this.ui = new PluginUI(this);
             this.Interface.UiBuilder.OnBuildUi += this.ui.Draw;

--- a/Dalamud.DiscordBridge/Plugin.cs
+++ b/Dalamud.DiscordBridge/Plugin.cs
@@ -55,12 +55,25 @@ namespace Dalamud.DiscordBridge
 
         private void ChatOnOnChatMessage(XivChatType type, uint senderid, ref SeString sender, ref SeString message, ref bool ishandled)
         {
-            this.Discord.MessageQueue.Enqueue(new QueuedChatEvent
+            if (type == XivChatType.RetainerSale)
             {
-                ChatType = type,
-                Message = message,
-                Sender = sender
-            });
+                this.Discord.MessageQueue.Enqueue(new QueuedRetainerItemSaleEvent 
+                {
+                    ChatType = type,
+                    Message = message,
+                    Sender = sender
+                });
+            }
+            else
+            {
+                this.Discord.MessageQueue.Enqueue(new QueuedChatEvent
+                {
+                    ChatType = type,
+                    Message = message,
+                    Sender = sender
+                });
+            }
+            
         }
 
         [Command("/pdiscord")]
@@ -80,6 +93,30 @@ namespace Dalamud.DiscordBridge
                 ChatType = XivChatType.Say,
                 Message = new SeString(new Payload[]{new TextPayload("Test Message"), }),
                 Sender = new SeString(new Payload[]{new TextPayload("Test Sender"), })
+            });
+        }
+
+        [Command("/dsaledebug")]
+        [HelpMessage("Show settings for the discord bridge plugin.")]
+        [DoNotShowInHelp]
+        public void SaleDebugCommand(string command, string args)
+        {
+            // make a sample sale message. This is using Titanium Ore for an item
+            Item sampleitem = Interface.Data.GetExcelSheet<Item>().GetRow(12537);
+            SeString sameplesale = new SeString(new Payload[] {new TextPayload("The "), new ItemPayload(Interface.Data, sampleitem.RowId, true), new TextPayload(sampleitem.Name) ,new TextPayload(" you put up for sale in the Crystarium markets has sold for 777 gil (after fees).") });
+
+            // PluginLog.Information($"Trying to make a fake sale: {sameplesale.TextValue}");
+
+            this.Discord.MessageQueue.Enqueue(new QueuedRetainerItemSaleEvent
+            {
+                ChatType = XivChatType.RetainerSale,
+                Message = sameplesale,
+                Sender = new SeString(new Payload[] { new TextPayload("Test Sender"), })
+            });
+
+            Interface.Framework.Gui.Chat.PrintChat(new XivChatEntry
+            {
+                MessageBytes = sameplesale.Encode()
             });
         }
 

--- a/Dalamud.DiscordBridge/Plugin.cs
+++ b/Dalamud.DiscordBridge/Plugin.cs
@@ -3,9 +3,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Dalamud.DiscordBridge.Attributes;
 using Dalamud.DiscordBridge.Model;
-using Dalamud.Game.Chat;
-using Dalamud.Game.Chat.SeStringHandling;
-using Dalamud.Game.Chat.SeStringHandling.Payloads;
+using Dalamud.Game.Text;
+using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Game.Text.SeStringHandling.Payloads;
 using Dalamud.Plugin;
 using Lumina.Excel.GeneratedSheets;
 

--- a/Dalamud.DiscordBridge/Plugin.cs
+++ b/Dalamud.DiscordBridge/Plugin.cs
@@ -32,23 +32,13 @@ namespace Dalamud.DiscordBridge
             
 
             this.Discord = new DiscordHandler(this);
-            //Task t = this.Discord.Start();
-            Task.Run(async () =>
+            // Task t = this.Discord.Start(); // bot won't start if we just have this
+            
+            Task.Run(async () => // makes the bot actually start
             {
                 await this.Discord.Start();
             });
-
-            // try to force-reload it
-            if (!this.Discord.IsConnected)
-            {
-                PluginLog.Information("Forcing DiscordBridge to run with Task.Run()");
-                this.Discord.Dispose();
-                this.Discord = new DiscordHandler(this);
-                Task.Run(async () =>
-                {
-                    await this.Discord.Start();
-                });
-            }
+            
 
             this.ui = new PluginUI(this);
             this.Interface.UiBuilder.OnBuildUi += this.ui.Draw;

--- a/Dalamud.DiscordBridge/Plugin.cs
+++ b/Dalamud.DiscordBridge/Plugin.cs
@@ -65,6 +65,8 @@ namespace Dalamud.DiscordBridge
 
         private void ChatOnOnChatMessage(XivChatType type, uint senderid, ref SeString sender, ref SeString message, ref bool ishandled)
         {
+            if (ishandled) return; // don't process a message that's been handled.
+
             if (type == XivChatType.RetainerSale)
             {
                 this.Discord.MessageQueue.Enqueue(new QueuedRetainerItemSaleEvent 

--- a/Dalamud.DiscordBridge/PluginUI.cs
+++ b/Dalamud.DiscordBridge/PluginUI.cs
@@ -65,7 +65,7 @@ namespace Dalamud.DiscordBridge
             if (this.plugin.Discord.State == DiscordState.Ready && ImGui.Button("Join my server"))
             {
                 Process.Start(
-                    $"https://discordapp.com/oauth2/authorize?client_id={this.plugin.Discord.UserId}&scope=bot&permissions=536947728");
+                    $"https://discordapp.com/oauth2/authorize?client_id={this.plugin.Discord.UserId}&scope=bot&permissions=537258064");
             }
 
             ImGui.Dummy(new Vector2(10, 10));

--- a/Dalamud.DiscordBridge/SpecialCharsHandler.cs
+++ b/Dalamud.DiscordBridge/SpecialCharsHandler.cs
@@ -46,11 +46,11 @@ namespace Dalamud.DiscordBridge
                 {
                     switch (guildEmote.Name)
                     {
-                        case "xivAtl": this.hqEmote = $"<:xivAtl:{guildEmote.Id}>";
+                        case "xivAtl": this.atlEmote = $"<:xivAtl:{guildEmote.Id}>";
                             return;
                         case "xivAtr": this.atrEmote = $"<:xivAtr:{guildEmote.Id}>";
                             return;
-                        case "xivHq": this.atlEmote = $"<:xivHq:{guildEmote.Id}>";
+                        case "xivHq": this.hqEmote = $"<:xivHq:{guildEmote.Id}>";
                             return;
                     }
                 }

--- a/Dalamud.DiscordBridge/XivApi/ItemResult.cs
+++ b/Dalamud.DiscordBridge/XivApi/ItemResult.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dalamud.DiscordBridge.XivApi
+{
+    public class ItemResult
+    {
+        public string Name { get; set; }
+        public string Icon { get; set; }
+    }
+}

--- a/Dalamud.DiscordBridge/XivApi/XivApiClient.cs
+++ b/Dalamud.DiscordBridge/XivApi/XivApiClient.cs
@@ -35,6 +35,21 @@ namespace Dalamud.DiscordBridge.XivApi
             return null;
         }
 
+        public static async Task<ItemResult> GetItem(uint itemId)
+        {
+            var res =  await Get($"Item/{itemId}", true);
+
+            // PluginLog.Information($"XIVAPI result: {res}");
+
+
+            return new ItemResult
+            {
+                Name = res?.Name,
+                Icon = res?.Icon,
+            };
+
+        }
+
         public static async Task<JObject> Search(string query, string indexes, int limit = 100, bool exact = false) {
             query = System.Net.WebUtility.UrlEncode(query);
 

--- a/Dalamud.DiscordBridge/XivChatTypeExtensions.cs
+++ b/Dalamud.DiscordBridge/XivChatTypeExtensions.cs
@@ -242,6 +242,13 @@ namespace Dalamud.DiscordBridge
                     }
                 },
                 {
+                    (XivChatType)68, new XivChatTypeInfo
+                    {
+                        Slug = "npcannounce",
+                        FancyName = "NPC Announcement"
+                    }
+                },
+                {
                     XivChatType.RetainerSale, new XivChatTypeInfo
                     {
                         Slug = "retainersale",

--- a/Dalamud.DiscordBridge/XivChatTypeExtensions.cs
+++ b/Dalamud.DiscordBridge/XivChatTypeExtensions.cs
@@ -232,8 +232,15 @@ namespace Dalamud.DiscordBridge
                         Slug = "e",
                         FancyName = "Echo"
                     }
-                }
+                },
                 // TODO: fellowships and shit, need dalamud update
+                {
+                    XivChatType.RetainerSale, new XivChatTypeInfo
+                    {
+                        Slug = "retainersale",
+                        FancyName = "Retainer Sale"
+                    }
+                }
             };
 
         public static XivChatTypeInfo GetInfo(this XivChatType type)

--- a/Dalamud.DiscordBridge/XivChatTypeExtensions.cs
+++ b/Dalamud.DiscordBridge/XivChatTypeExtensions.cs
@@ -235,6 +235,13 @@ namespace Dalamud.DiscordBridge
                 },
                 // TODO: fellowships and shit, need dalamud update
                 {
+                    (XivChatType)61, new XivChatTypeInfo
+                    {
+                        Slug = "npctalk",
+                        FancyName = "NPC Talk"
+                    }
+                },
+                {
                     XivChatType.RetainerSale, new XivChatTypeInfo
                     {
                         Slug = "retainersale",

--- a/Dalamud.DiscordBridge/XivChatTypeExtensions.cs
+++ b/Dalamud.DiscordBridge/XivChatTypeExtensions.cs
@@ -233,7 +233,16 @@ namespace Dalamud.DiscordBridge
                         FancyName = "Echo"
                     }
                 },
+                {
+                    XivChatType.SystemMessage, new XivChatTypeInfo
+                    {
+                        Slug = "sysmsg",
+                        FancyName = "SystemMessage"
+                    }
+                },
                 // TODO: fellowships and shit, need dalamud update
+
+                // Custom types not defined in Dalamud
                 {
                     (XivChatType)61, new XivChatTypeInfo
                     {
@@ -253,6 +262,112 @@ namespace Dalamud.DiscordBridge
                     {
                         Slug = "retainersale",
                         FancyName = "Retainer Sale"
+                    }
+                },
+                // Special handling for GM types
+                {
+                    (XivChatType)80, new XivChatTypeInfo
+                    {
+                        Slug = "gmtelly",
+                        FancyName = "GM Tell"
+                    }
+                },
+                {
+                    (XivChatType)81, new XivChatTypeInfo
+                    {
+                        Slug = "gmsay",
+                        FancyName = "Say"
+                    }
+                },
+                {
+                    (XivChatType)82, new XivChatTypeInfo
+                    {
+                        Slug = "gmshout",
+                        FancyName = "GM Shout"
+                    }
+                },
+                {
+                    (XivChatType)83, new XivChatTypeInfo
+                    {
+                        Slug = "gmyell",
+                        FancyName = "GM Yell"
+                    }
+                },
+                {
+                    (XivChatType)84, new XivChatTypeInfo
+                    {
+                        Slug = "gmp",
+                        FancyName = "GM Party Chat"
+                    }
+                },
+                {
+                    (XivChatType)85, new XivChatTypeInfo
+                    {
+                        Slug = "gmfc",
+                        FancyName = "GM Free Company"
+                    }
+                },
+                {
+                    (XivChatType)86, new XivChatTypeInfo
+                    {
+                        Slug = "gmls1",
+                        FancyName = "GM Linkshell 1"
+                    }
+                },
+                {
+                    (XivChatType)87, new XivChatTypeInfo
+                    {
+                        Slug = "gmls2",
+                        FancyName = "GM Linkshell 2"
+                    }
+                },
+                {
+                    (XivChatType)88, new XivChatTypeInfo
+                    {
+                        Slug = "gmls3",
+                        FancyName = "GM Linkshell 3"
+                    }
+                },
+                {
+                    (XivChatType)89, new XivChatTypeInfo
+                    {
+                        Slug = "gmls4",
+                        FancyName = "GM Linkshell 4"
+                    }
+                },
+                {
+                    (XivChatType)90, new XivChatTypeInfo
+                    {
+                        Slug = "gmls5",
+                        FancyName = "GM Linkshell 5"
+                    }
+                },
+                {
+                    (XivChatType)91, new XivChatTypeInfo
+                    {
+                        Slug = "gmls6",
+                        FancyName = "GM Linkshell 6"
+                    }
+                },
+                {
+                    (XivChatType)92, new XivChatTypeInfo
+                    {
+                        Slug = "gmls7",
+                        FancyName = "GM Linkshell 7"
+                    }
+                },
+                {
+                    (XivChatType)93, new XivChatTypeInfo
+                    {
+                        Slug = "gmls8",
+                        FancyName = "GM Linkshell 8"
+                    }
+                },
+                {
+                    (XivChatType)94, new XivChatTypeInfo
+                    {
+                        Slug = "gmnn",
+                        FancyName = "GM Novice Network"
                     }
                 }
             };

--- a/Dalamud.DiscordBridge/XivChatTypeExtensions.cs
+++ b/Dalamud.DiscordBridge/XivChatTypeExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Dalamud.Game.Chat;
+using Dalamud.Game.Text;
 
 namespace Dalamud.DiscordBridge
 {


### PR DESCRIPTION
Users weren't sure how to unset a channel prefix as it wasn't documented anywhere. Rather than pitch the "none" feature I found in the code, I added a dedicated command and help for this as I think that will be easier on users to figure out.

For some reason, the linq code doesn't seem to like working when something's been removed, but there's still something left. I don't know why. If this is something I can fix pre-commit, lemme know in comments and I'll re-test!